### PR TITLE
add gap after label

### DIFF
--- a/src/component.vue
+++ b/src/component.vue
@@ -229,7 +229,8 @@ $variables: (
   &__label {
     font-weight: bold;
 
-    display: block;
+    display: flex;
+    gap: $spacing / 2;
 
     &-required {
       color: GetVariable("error");


### PR DESCRIPTION
- add a default gap between label and after-label slot